### PR TITLE
hostname argument and exception for float() to avoid valueerrors

### DIFF
--- a/controllers/system_controller.py
+++ b/controllers/system_controller.py
@@ -88,7 +88,7 @@ class System(object):
 
     def get_ip(self):
         try:
-            return check_output(['hostname', '-i']).rstrip('\n').split()[0]
+            return check_output(['hostname', '-I']).rstrip('\n').split()[0]
         except IndexError as e:
             return ''
         except Exception as e:
@@ -141,10 +141,16 @@ class System(object):
         temperature = 0
         if thermal_zones:
             # get the temperatures and sum them up
+            thermal_zone_count = 0
             for zone in thermal_zones:
-                temperature += float(os.popen('cat '+zone+'/temp').readline().strip())/1000
+                try:
+                    temperature += float(os.popen('cat '+zone+'/temp').readline().strip())/1000
+                    thermal_zone_count += 1
+                except:
+                    pass
             # calculate the average
-            temperature /= len(thermal_zones)
+            if thermal_zone_count > 0:
+                temperature /= thermal_zone_count#len(thermal_zones)
 
         usage = self.cpu_load.get_cpu_load()
         return {


### PR DESCRIPTION
This pull request contains two possible fixes..

1, it changes hostname argument from -i to -I in get_ip() of system_controller.py, as mentioned in #22 

2, it adds a try/except around the float conversion in get_cpu() of system_controller.py avoiding a ValueError, when the system call to cat /sys/class/..etc.. returns 'No data available' or any other return value with no number to parse.

This happened for me on a NUC10 with ubuntu 18.04.5 and kernel 5.

The error leaked memory and because it happened continuously every time the frontend requested temperature data the computer ended up non-responsive due to all memory being used.

